### PR TITLE
Fix toast message script generation and redesign settings buttons

### DIFF
--- a/PetFeeder_code_V3.1.ino
+++ b/PetFeeder_code_V3.1.ino
@@ -210,6 +210,11 @@ String commonHeaderCSS(){
     ".pill{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;border:1px solid #2b2e45;color:#f0f1ff;background:rgba(0,0,0,.18)}\n"
     ".row{display:flex;gap:12px;flex-wrap:wrap;align-items:center}\n"
     ".rowcol{display:grid;gap:6px}\n"
+    ".actions-grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr))}\n"
+    ".btn.warn{background:#f59e0b;color:#111827;border:none}\n"
+    ".btn.danger{background:#dc2626;color:#fff;border:none}\n"
+    ":root.light .btn.warn{background:#fbbf24;color:#111827}\n"
+    ":root.light .btn.danger{background:#f87171;color:#fff}\n"
     ".toast{position:fixed;right:16px;top:16px;display:grid;gap:10px;z-index:9999}\n"
     ".toast .t{background:#111827;color:#e5e7eb;border:1px solid #2b2e45;padding:10px 14px;border-radius:12px;box-shadow:0 10px 20px rgba(0,0,0,.35)}\n"
     "svg,svg *{fill:currentColor!important;stroke:currentColor!important;stroke-width:0!important}\n"
@@ -461,23 +466,28 @@ String htmlSettingsPage(bool saved,const String& toastMsg){
          "<div><label>Webhook URL</label><input name='webhook_url' value='"); h+=cfg.webhook_url; h+=F("'></div>"
          "</section>");
 
-  h += F("<section class='card'><div class='row'>"
+  h += F("<section class='card'><div class='actions-grid'>"
          "<button class='primary' type='submit'>💾 Enregistrer</button>"
          "<a class='btn' href='/backup'>📤 Exporter config</a>"
          "<button type='button' id='btnImportCfg' class='btn'>📥 Importer config…</button>"
-         "<a class='btn' href='/reboot'>⟲ Reboot</a>"
-         "<a class='btn' href='/stats/clear'>🧹 Effacer historique 7j</a>"
-         "<a class='btn' href='/factory'>🔄 Réinitialiser usine</a>"
+         "<a class='btn warn' href='/reboot'>⟲ Reboot</a>"
+         "<a class='btn warn' href='/stats/clear'>🧹 Effacer historique 7j</a>"
+         "<a class='btn danger' href='/factory'>🔄 Réinitialiser usine</a>"
          "<input type='file' id='fres_settings' style='display:none' accept='application/json'>"
          "</div></section></form>");
 
   h += F("<div class='toast' id='toast'></div>"
          "<script>"
-         "document.addEventListener('DOMContentLoaded',()=>{" 
+         "document.addEventListener('DOMContentLoaded',()=>{"
          "const q=(s)=>document.querySelector(s); const root=document.documentElement;"
          "function applyTheme(t){if(t==='light'){root.classList.add('light');}else{root.classList.remove('light');} localStorage.setItem('pf_theme',t);} applyTheme(localStorage.getItem('pf_theme')||'dark');"
          "const themeBtn=document.querySelector('#theme'); if(themeBtn) themeBtn.onclick=()=>applyTheme(root.classList.contains('light')?'dark':'light');"
-         "const toastMsg='"+toastMsg+"'; if(toastMsg){const t=document.createElement('div'); t.className='t'; t.textContent=toastMsg; q('#toast').appendChild(t); setTimeout(()=>t.remove(),2200); }"
+         );
+  h += F("const toastMsg='");
+  h += toastMsg;
+  h += F("'; if(toastMsg){const t=document.createElement('div');"
+         "t.className='t'; t.textContent=toastMsg;"
+         "q('#toast').appendChild(t); setTimeout(()=>t.remove(),2200); }"
          "q('#btnImportCfg').onclick=()=>q('#fres_settings').click();"
          "q('#fres_settings').onchange=async()=>{const f=q('#fres_settings').files[0]; if(!f) return; const txt=await f.text(); await fetch('/restore',{method:'POST',headers:{'Content-Type':'application/json'},body:txt}); location.href='/settings?saved=1';};"
          "function two(n){return (n<10?'0':'')+n;} function updateClock(){const e=document.querySelector('#nowFr'); if(!e)return; const d=new Date(); e.textContent=`${two(d.getHours())}:${two(d.getMinutes())}:${two(d.getSeconds())} ${two(d.getDate())}/${two(d.getMonth()+1)}/${d.getFullYear()}`;} setInterval(updateClock,1000); updateClock();"


### PR DESCRIPTION
## Summary
- split HTML settings page toast script into constant and variable parts to avoid F() macro concatenation errors
- restyle settings action buttons with a responsive grid and warning/danger color cues

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno PetFeeder_code_V3.1.ino` *(fails: command not found)*
- `apt-get install -y arduino-cli` *(fails: Unable to locate package)*
- `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af84202c908333932bc20c5c04ef01