### PR TITLE
Add save button to settings page

### DIFF
--- a/PetFeeder_code_V3.1.ino
+++ b/PetFeeder_code_V3.1.ino
@@ -468,6 +468,7 @@ String htmlSettingsPage(bool saved,const String& toastMsg){
          "</section>");
 
   h += F("<section class='card'><div class='actions-grid'>"
+         "<button type='submit' class='btn primary'>💾 Enregistrer</button>"
          "<a class='btn' href='/backup'>📤 Exporter config</a>"
          "<button type='button' id='btnImportCfg' class='btn'>📥 Importer config…</button>"
          "<a class='btn warn' href='/reboot'>⟲ Reboot</a>"


### PR DESCRIPTION
## Summary
- add missing save button to Settings form so configuration changes can be submitted

## Testing
- `arduino-cli compile --fqbn esp8266:esp8266:generic PetFeeder_code_V3.1.ino` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af961d4140833392df852e18f40ee5