### PR TITLE
Organize maintenance actions into dedicated settings card

### DIFF
--- a/PetFeeder_code_V3.1.ino
+++ b/PetFeeder_code_V3.1.ino
@@ -467,13 +467,16 @@ String htmlSettingsPage(bool saved,const String& toastMsg){
          "<div><label>Webhook URL</label><input name='webhook_url' value='"); h+=cfg.webhook_url; h+=F("'></div>"
          "</section>");
 
+  h += F("<section class='card grid g2'>"
+         "<div><a class='btn warn' href='/reboot'>⟲ Reboot</a></div>"
+         "<div><a class='btn warn' href='/stats/clear'>🧹 Effacer historique 7j</a></div>"
+         "<div><a class='btn danger' href='/factory'>🔄 Réinitialiser usine</a></div>"
+         "</section>");
+
   h += F("<section class='card'><div class='actions-grid'>"
          "<button type='submit' class='btn primary'>💾 Enregistrer</button>"
          "<a class='btn' href='/backup'>📤 Exporter config</a>"
          "<button type='button' id='btnImportCfg' class='btn'>📥 Importer config…</button>"
-         "<a class='btn warn' href='/reboot'>⟲ Reboot</a>"
-         "<a class='btn warn' href='/stats/clear'>🧹 Effacer historique 7j</a>"
-         "<a class='btn danger' href='/factory'>🔄 Réinitialiser usine</a>"
          "<input type='file' id='fres_settings' style='display:none' accept='application/json'>"
          "</div></section></form>");
 


### PR DESCRIPTION
## Summary
- Move reboot, statistics clear, and factory reset buttons into a dedicated card
- Place maintenance card before save/export/import controls so actions remain last

## Testing
- `arduino-cli version` *(failed: command not found)*
- `apt-get install -y arduino-cli` *(failed: Unable to locate package arduino-cli)*
- `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b044023c7c8333924a1dc8ea2c3983