### PR TITLE
Remove duplicate controls on settings page

### DIFF
--- a/PetFeeder_code_V3.1.ino
+++ b/PetFeeder_code_V3.1.ino
@@ -480,11 +480,7 @@ String htmlSettingsPage(bool saved,const String& toastMsg){
          "<input type='file' id='fres_settings' style='display:none' accept='application/json'>"
          "</div></section>");
 
-  h += F("<section class='card grid g2'>"
-         "<div><a class='btn warn' href='/reboot'>⟲ Reboot</a></div>"
-         "<div><a class='btn warn' href='/stats/clear'>🧹 Effacer historique 7j</a></div>"
-         "<div><a class='btn danger' href='/factory'>🔄 Réinitialiser usine</a></div>"
-         "</section></form>");
+  h += F("</form>");
 
   h += F("<div class='toast' id='toast'></div>"
          "<script>"


### PR DESCRIPTION
## Summary
- Remove redundant settings actions block (Reboot, clear stats, factory reset) at bottom of page
- Close settings form once after actions grid

## Testing
- `g++ -fsyntax-only PetFeeder_code_V3.1.ino`
- `sudo apt-get install -y arduino-cli` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0494b90fc8333becebad54b243f7e