### PR TITLE
Switch CI build to Arduino CLI for ESP8266

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+---
+'on':
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+  pull_request:
+
+name: Build and Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Arduino CLI
+        uses: arduino/setup-arduino-cli@v1
+
+      - name: Install board dependencies
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install esp8266:esp8266
+
+      - name: Compile sketch
+        run: |
+          arduino-cli compile \
+            --fqbn esp8266:esp8266:d1_mini \
+            PetFeeder_code.ino \
+            --output-dir build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: firmware
+          path: build/*.bin
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/PetFeeder_code.ino.bin
+          asset_name: PetFeeder_code.ino.bin
+          asset_content_type: application/octet-stream

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             --output-dir build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: firmware
           path: build/*.bin


### PR DESCRIPTION
## Summary
- set up Arduino CLI instead of PlatformIO
- install ESP8266 core and compile PetFeeder sketch
- upload build artifact and release binary on tag builds

## Testing
- `yamllint .github/workflows/build.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b975823690833380d4abab94cefbef