### PR TITLE
Define firmware version constant and use it

### DIFF
--- a/PetFeeder.ino
+++ b/PetFeeder.ino
@@ -64,6 +64,8 @@
 #include <Updater.h>
 #include <FS.h>
 
+#define FW_VERSION "1.0"
+
 // ---------- PINS ----------
 #define PIN_DIR   14  // D5
 #define PIN_STEP  12  // D6
@@ -810,7 +812,7 @@ void setup(){
   server.begin();
   attachInterrupt(digitalPinToInterrupt(PIN_BTN), btnISR, CHANGE);
 
-  logEvent(LOG_INFO,"BOOT","host="+hostName+" v4.0");
+  logEvent(LOG_INFO,"BOOT","host="+hostName+" v" FW_VERSION);
 }
 
 void loop(){


### PR DESCRIPTION
## Summary
- add FW_VERSION constant for firmware version, set to 1.0
- reference FW_VERSION instead of hardcoded version during boot logging

## Testing
- `arduino-cli compile -b esp8266:esp8266:nodemcuv2 PetFeeder.ino` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b97dad9c3483338923e4ee89db9fd6